### PR TITLE
Put "ssdp-discover" in quotation marks

### DIFF
--- a/src/clj_ssdp/client.clj
+++ b/src/clj_ssdp/client.clj
@@ -50,7 +50,7 @@
 (defn discover
   ([^long timeout ^String search-target]
    {:pre [(pos-int? timeout)]}
-   (let [msearch (str "M-SEARCH * HTTP/1.1\nHost: 239.255.255.250:1900\nMAN: ssdp:discover\nST: " search-target "\n")
+   (let [msearch (str "M-SEARCH * HTTP/1.1\nHost: 239.255.255.250:1900\nMAN: \"ssdp:discover\"\nST: " search-target "\n")
          msearch (str msearch "MX: " (long (/ timeout 1000)) "\n\r\n")
          ^bytes send-data (.getBytes msearch)
          ^bytes receive-data (byte-array 1024)

--- a/src/clj_ssdp/client.clj
+++ b/src/clj_ssdp/client.clj
@@ -23,7 +23,7 @@
 (defn discover-one
   ([^long timeout ^String search-target]
    {:pre [(pos-int? timeout)]}
-   (let [msearch (str "M-SEARCH * HTTP/1.1\nHost: 239.255.255.250:1900\nMAN: ssdp:discover\nST: " search-target "\n")
+   (let [msearch (str "M-SEARCH * HTTP/1.1\nHost: 239.255.255.250:1900\nMAN: \"ssdp:discover\"\nST: " search-target "\n")
          msearch (str msearch "MX: " (long (/ timeout 1000)) "\n\r\n")
          send-data (.getBytes msearch)
          receive-data (byte-array 1024)


### PR DESCRIPTION
When I try your library on my computer I get a SocketTimeoutException.
After looking at the [Python library](https://github.com/5kyc0d3r/upnpy/blob/master/upnpy/ssdp/SSDPRequest.py) which works on my machine I discovered that ssdp-discover is put in quotes. Now the discovery works like a charm.